### PR TITLE
Allow to reset callback function for thread ID.

### DIFF
--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -475,7 +475,7 @@ extern int FIPS_crypto_threadid_set_callback(void (*func) (CRYPTO_THREADID *));
 
 int CRYPTO_THREADID_set_callback(void (*func) (CRYPTO_THREADID *))
 {
-    if (threadid_callback)
+    if (threadid_callback && func)
         return 0;
     threadid_callback = func;
 #ifdef OPENSSL_FIPS


### PR DESCRIPTION
This change was made to fix error on GR side (gmat-swx). It looks like openssh was initializing thread ID callback with its own function. Then when finalizing things (after pressing power off button) openssh tries to reset this callback to NULL but it isn't possible in current implementation. Then boost asio tries to finalize and calls some methods from openssl. One of those methods uses thread ID callback which points to method fro already unloaded openssh DLL.